### PR TITLE
fix: could not open device

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.18
 
 require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
-	github.com/karalabe/hid v1.0.0
+	github.com/karalabe/hid v1.0.1-0.20240919124526-821c38d2678e
 	golang.org/x/image v0.15.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,7 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF0
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/karalabe/hid v1.0.0 h1:+/CIMNXhSU/zIJgnIvBD2nKHxS/bnRHhhs9xBryLpPo=
 github.com/karalabe/hid v1.0.0/go.mod h1:Vr51f8rUOLYrfrWDFlV12GGQgM5AT8sVh+2fY4MPeu8=
+github.com/karalabe/hid v1.0.1-0.20240919124526-821c38d2678e h1:ryNJIEs1fyZNVwJ/Dsz7+EFZTow0ggBdnAIVo8SAs+A=
+github.com/karalabe/hid v1.0.1-0.20240919124526-821c38d2678e/go.mod h1:qk1sX/IBgppQNcGCRoj90u6EGC056EBoIc1oEjCWla8=
 golang.org/x/image v0.15.0 h1:kOELfmgrmJlw4Cdb7g/QGuB3CvDrXbqEIww/pNtNBm8=
 golang.org/x/image v0.15.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=

--- a/main.go
+++ b/main.go
@@ -255,16 +255,16 @@ func main() {
 	flag.Parse()
 	var usbIDVendor, usbIDDevice uint16
 	fmt.Sscanf(*usbIDFlag, "%04x:%04x", &usbIDVendor, &usbIDDevice)
-	di := hid.Enumerate(usbIDVendor, usbIDDevice)
+	di, err := hid.Enumerate(usbIDVendor, usbIDDevice)
 	if len(di) < 1 {
 		log.Fatalf("Could not find any devices")
 	}
-
-	dev, err := di[*deviceIndex].Open()
+	dev := di[*deviceIndex]
+	devOpen, err := di[*deviceIndex].Open()
 	if err != nil {
 		log.Fatalf("Could not open device %#v: %s", di[0], err)
 	}
-	defer dev.Close()
+	defer devOpen.Close()
 	log.Printf("Opened %s / %s @ %s", dev.Manufacturer, dev.Product, dev.Path)
 
 	var p *Packet
@@ -370,5 +370,9 @@ func main() {
 	if l := len(buf); l > 8192 {
 		log.Fatalf("Too long buffer (%d), max is 8192", l)
 	}
-	dev.Write(buf)
+
+	_, err = devOpen.Write(buf)
+	if err != nil {
+		log.Fatalf("Could not write to device %#v: %s", di[0], err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -256,6 +256,9 @@ func main() {
 	var usbIDVendor, usbIDDevice uint16
 	fmt.Sscanf(*usbIDFlag, "%04x:%04x", &usbIDVendor, &usbIDDevice)
 	di, err := hid.Enumerate(usbIDVendor, usbIDDevice)
+	if err != nil {
+		log.Fatal("Could not enumerate USB device:", err)
+	}
 	if len(di) < 1 {
 		log.Fatalf("Could not find any devices")
 	}


### PR DESCRIPTION
Source code from this [ref](https://github.com/fossasia/badgemagic-go/commit/c443092149082aa11d1268001e9ea22119b8b301) produces following error when running on `darwin`:

```bash
sudo ./badgemagic-tool -mode center -font ./fonts/MesloLGLNerdFont-Bold.ttf "text1" "text2"
Password:
2025/03/15 19:20:34 Could not open device hid.DeviceInfo{Path:"", VendorID:0x416, ProductID:0x5020, Release:0x0, Serial:"", Manufacturer:"wch.cn", Product:"CH583", UsagePage:0xff00, Usage:0x1, Interface:-1}: hidapi: failed to open device
```

 This is because the package `github.com/karalabe/hid` is pinned to `v1.0.0`, which was released in 2019: <https://github.com/karalabe/hid/tags>.

---

The fix is to pin the hid package to latest commit, and now it works correctly on darwin:

```bash
Marshalled data:
00000000  77 61 6e 67 00 00 00 00  54 54 00 00 00 00 00 00  |wang....TT......|
00000010  00 04 00 04 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000020  00 00 00 00 00 00 19 03  0f 13 2d 05 00 00 00 00  |..........-.....|
00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000040  00 7c 6c 44 4c 7c 6c 46  6e 7c 00 00 8c 8d 8d 8d  |.|lDL|lFn|......|
00000050  8c 8c 8c f9 71 00 00 f6  b3 83 c1 f1 30 10 b0 e0  |....q.......0...|
00000060  00 00 30 20 60 c0 c0 c0  80 80 80 00 00 46 4c 58  |..0 `........FLX|
00000070  70 78 78 4c 4c 47 00 00  71 71 71 59 d9 f9 f9 8d  |pxxLLG..qqqY....|
00000080  8d 00 00 f3 b3 93 b3 e2  f2 b2 9a 9a 00 00 30 30  |..............00|
00000090  30 b0 b0 f0 70 70 70 00  00 00 00 00 00 00 00 00  |0...ppp.........|
000000a0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000000b0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
2025/03/15 19:45:05 Opened wch.cn / CH583 @ DevSrvsID:4297168806
```
A

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the device could not be opened on Darwin due to an outdated version of the github.com/karalabe/hid package.